### PR TITLE
fix for playlist download

### DIFF
--- a/library/spotify.py
+++ b/library/spotify.py
@@ -74,12 +74,12 @@ class LoadPlaylist:
 		console.success('Playlist name is =={0}== by =={1}=='.format(self.metadata.name, self.metadata.owner))
 
 	def request_playlist_tracks(self):
-		results = self.SPClient.user_playlist_tracks(self.username, self.playlist_id)
+		results = self.SPClient.user_playlist_tracks(self.username, self.playlist_id, offset=250, limit=5)
 		self.add_playlist_results(results)
 		if 'next' in results:
 			while results['next']:
-				next_results = self.SPClient.next(results)
-				self.add_playlist_results(next_results)
+				results = self.SPClient.next(results)
+				self.add_playlist_results(results)
 
 	def add_playlist_results(self, results):
 		if 'tracks' not in results:

--- a/library/spotify.py
+++ b/library/spotify.py
@@ -74,7 +74,7 @@ class LoadPlaylist:
 		console.success('Playlist name is =={0}== by =={1}=='.format(self.metadata.name, self.metadata.owner))
 
 	def request_playlist_tracks(self):
-		results = self.SPClient.user_playlist_tracks(self.username, self.playlist_id, offset=250, limit=5)
+		results = self.SPClient.user_playlist_tracks(self.username, self.playlist_id)
 		self.add_playlist_results(results)
 		if 'next' in results:
 			while results['next']:

--- a/library/spotify.py
+++ b/library/spotify.py
@@ -75,28 +75,24 @@ class LoadPlaylist:
 
 	def request_playlist_tracks(self):
 		results = self.SPClient.user_playlist_tracks(self.username, self.playlist_id)
-		if ('items' in results):
-			for data in results['items']:
-				data = objectify(data)
-				self.tracks.append(objectify({
-					'duration': data.track.duration_ms / 1e3,
-					'link': data.track.external_urls.spotify,
-					'name': data.track.name,
-					'number': data.track.track_number
-				}))
-		while 'next' in results:
-			results = self.SPClient.next(results)
-			if (results):
-				for data in results['items']:
-					data = objectify(data)
-					self.tracks.append(objectify({
-						'duration': data.track.duration_ms / 1e3,
-						'link': data.track.external_urls.spotify,
-						'name': data.track.name,
-						'number': data.track.track_number
-					}))
-			else:
-				break
+		self.add_playlist_results(results)
+		if 'next' in results:
+			while results['next']:
+				next_results = self.SPClient.next(results)
+				self.add_playlist_results(next_results)
+
+	def add_playlist_results(self, results):
+		if 'tracks' not in results:
+			console.warning('No tracks in playlist found!')
+			return
+		for data in results['tracks']['items']:
+			data = objectify(data)
+			self.tracks.append(objectify({
+				'duration': data.track.duration_ms / 1e3,
+				'link': data.track.external_urls.spotify,
+				'name': data.track.name,
+				'number': data.track.track_number
+			}))
 
 	def dump_file(self):
 		file_path = os.path.join(self.save_path, self.metadata.name+'.txt')


### PR DESCRIPTION
The fix didn't work for me, the track for the current spotipy module is under: `results['tracks']['items']`. Also, there is a limit of 100 songs which seems to be from the API. But changing the offset or limit parameters in `self.SPClient.user_playlist_tracks` doesn't work for me, there is also no `next` parameter. Not sure if that is a case for the spotipy developers.